### PR TITLE
Expected file name conflict fix

### DIFF
--- a/DiffAssertions.Tests/DiffAssertTests/DiffAssertTests.cs
+++ b/DiffAssertions.Tests/DiffAssertTests/DiffAssertTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 using TestHelpers.DiffAssertions;

--- a/DiffAssertions.Tests/DiffAssertTests/DiffAssertTests.cs
+++ b/DiffAssertions.Tests/DiffAssertTests/DiffAssertTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using TestHelpers.DiffAssertions;
@@ -20,6 +21,18 @@ namespace DiffAssertTests
             DiffAssert
                 .ThatContentsOf("DiffAssertTests/FileWithContentThatShouldMatchTheActualValue")
                 .Equals("The actual value");
+        }
+
+        [Fact]
+        public void GivenThatMultipleExpectedFilesInDifferentDirectoriesShareTheSameNameAndBothDiff_ThenCreatesTwoActualFilesWithoutConflict()
+        {
+            Assert.ThrowsAny<DiffAssertException>(() => DiffAssert
+                .ThatContentsOf("DiffAssertTests/Directory1/FileWithSameNameAsOtherInDifferentDirectory")
+                .Equals("Value different from expected file value"));
+
+            Assert.ThrowsAny<DiffAssertException>(() => DiffAssert
+                .ThatContentsOf("DiffAssertTests/Directory2/FileWithSameNameAsOtherInDifferentDirectory")
+                .Equals("Value different from expected file value"));
         }
 
         [Fact]

--- a/DiffAssertions.Tests/DiffAssertTests/Directory1/FileWithSameNameAsOtherInDifferentDirectory.expected.txt
+++ b/DiffAssertions.Tests/DiffAssertTests/Directory1/FileWithSameNameAsOtherInDifferentDirectory.expected.txt
@@ -1,0 +1,1 @@
+﻿DO NOT OVERWRITE!

--- a/DiffAssertions.Tests/DiffAssertTests/Directory2/FileWithSameNameAsOtherInDifferentDirectory.expected.txt
+++ b/DiffAssertions.Tests/DiffAssertTests/Directory2/FileWithSameNameAsOtherInDifferentDirectory.expected.txt
@@ -1,0 +1,1 @@
+﻿DO NOT OVERWRITE!

--- a/DiffAssertions.Tests/DiffAssertions.Tests.csproj
+++ b/DiffAssertions.Tests/DiffAssertions.Tests.csproj
@@ -42,4 +42,9 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="DiffAssertTests\Directory1\" />
+    <Folder Include="DiffAssertTests\Directory2\" />
+  </ItemGroup>
+
 </Project>

--- a/DiffAssertions/DefaultImplementations/TestFileManager.cs
+++ b/DiffAssertions/DefaultImplementations/TestFileManager.cs
@@ -60,12 +60,37 @@ content for future use
 
         public ITestFile CreateActualFile(ITestFile expectedFile, string actualValue)
         {
+            var workingDirectory = string.IsNullOrEmpty(_rootFolder)
+                ? Directory.GetCurrentDirectory()
+                : _rootFolder;
+
+            var actualFilesRootDirectory = _tempDirectoryForStringComparisons.Value.FullName;
+
+            var relativeDirectoryPath = GetRelativeDirectoryPath(expectedFile.FullName, workingDirectory);
+
+            var directory = Directory.CreateDirectory(Path.Combine(actualFilesRootDirectory, relativeDirectoryPath));
+
             var fileName = expectedFile.Name.Replace(".expected.txt", ".actual.txt");
-            var fullName = Path.Combine(_tempDirectoryForStringComparisons.Value.FullName, fileName);
-            var actualFile = new FileInfo(fullName);
+            
+            var actualFile = new FileInfo(Path.Combine(directory.FullName, fileName));
             actualFile.WriteAllText(actualValue);
 
             return new TestFile(actualFile);
+        }
+
+        private static string GetRelativeDirectoryPath(
+            string fullFileName,
+            string workingDirectory)
+        {
+            if (!fullFileName.StartsWith(workingDirectory)) return string.Empty;
+
+            var fullDirectoryPath = Path.GetDirectoryName(fullFileName);
+
+            if (string.IsNullOrEmpty(fullDirectoryPath)) return string.Empty;
+
+            return fullDirectoryPath
+                .Substring(workingDirectory.Length)
+                .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
     }
 }


### PR DESCRIPTION
Expected files in different folders within the working directory can now share the same name